### PR TITLE
Changed map functionality in device overview

### DIFF
--- a/includes/html/dev-overview-data.inc.php
+++ b/includes/html/dev-overview-data.inc.php
@@ -147,16 +147,21 @@ if ($device['location_id']) {
     <script>
         var device_marker, device_location, device_map;
         $("#toggle-map").on("shown.bs.collapse", function () {
-            if (device_marker == null) {
+             if (device_marker == null) {
+
                 device_location = new L.LatLng(' . (float) $location->lat . ', ' . (float) $location->lng . ');
                 config = {"tile_url": "' . Config::get('leaflet.tile_url', '{s}.tile.openstreetmap.org') . '"};
                 device_map = init_map("location-map", "' . $maps_engine . '", "' . $maps_api . '", config);
-                device_marker = init_map_marker(device_map, device_location);
+                device_marker = L.marker(device_location).addTo(device_map);
+                device_map.setView(device_location);
                 device_map.setZoom(18);
+                device_marker.dragging.enable();
+
+
                 ';
 
     if (Auth::user()->isAdmin()) {
-        echo '  device_map.on("dragend", function () {
+        echo '  device_marker.on("dragend", function () {
                     var new_location = device_marker.getLatLng();
                     if (confirm("Update location to " + new_location + "? This will update this location for all devices!")) {
                         update_location(' . $location->id . ', new_location, function(success) {


### PR DESCRIPTION
Changed map in overview page for devices so that it is possible to move and drop the marker to update position, and possible to pan/move map without marker being stuck in center, marker stays in its fixed position.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
